### PR TITLE
fix(parser): handle case with LTChar directly under page

### DIFF
--- a/implporter/src/schemify.py
+++ b/implporter/src/schemify.py
@@ -5,6 +5,8 @@ import re
 
 def get_container_info(elem):
     for text_line in elem:
+        if isinstance(text_line, LTChar):
+            text_line = [text_line]
         for char in text_line:
             if isinstance(char, LTChar):
                 return (char.fontname, char.size)

--- a/implporter/src/schemify.py
+++ b/implporter/src/schemify.py
@@ -12,6 +12,12 @@ def get_container_info(elem):
                 return (char.fontname, char.size)
     return (None, None)
 
+
+def get_tag_from_size(siz, config, error_margin=0.3):
+    for k, v in config['sizes'].items():
+        if abs(k - siz) < error_margin:
+            return v
+
 MIDI_REF_CONFIG = {
     "pdf": "doc-inputs/jupx-midi-ref.pdf",
     "output_map": "../sysex-maps/jupx.json",
@@ -428,7 +434,7 @@ class MapMaker(object):
 
                     # attempt to map boxes based on the size of their contents
                     (fontname, size) = get_container_info(element)
-                    tag = config["sizes"].get(size)
+                    tag = get_tag_from_size(size, config)
                     if tag is None:
                         continue
 

--- a/implporter/src/to_yaml.py
+++ b/implporter/src/to_yaml.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+"""Use this if you want to represent jupx.json as a YAML
+with hex numbers for readability"""
+import yaml
+
+def hex_representer(dumper, data):
+    return dumper.represent_int(hex(data))
+
+
+yaml.add_representer(int, hex_representer, Dumper=yaml.CDumper)
+
+def to_nice_yaml(in_json, out_yaml):
+    data = None
+    with open(in_json, 'rb') as fhin:
+        data = yaml.load(fhin, Loader=yaml.CLoader)
+    with open(out_yaml, 'w', encoding='utf-8') as fhout:
+        yaml.dump(data, stream=fhout, Dumper=yaml.CDumper, sort_keys=False, indent=2)
+
+if __name__ == '__main__':
+  to_nice_yaml('../sysex-maps/jupx.json', '../sysex-maps/jupx.yaml')


### PR DESCRIPTION
Some characters are directly under a LTPage and this makes the parser crash when using pdfminer.six==20231228 as LTChar are not iterable.

(tested with the Jupiter XM MIDI spec ref file with prefix `eng06_W.pdf`)